### PR TITLE
Replace placeholders with jupyterhub, link to quay.io

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -30,10 +30,9 @@ env:
   # If this is a backport then change this to the name of the backports branch
   PUBLISH_BRANCH: main
 
-  # IMAGE: jupyterhub/jupyterhub
-  IMAGE: manics/jupyterhub-image-test
-  SINGLEUSER: manics/jupyterhub-singleuser-image-test
-  PUBLISH_DOCKERIO: "false"
+  IMAGE: jupyterhub/jupyterhub
+  SINGLEUSER: jupyterhub/singleuser
+  PUBLISH_DOCKERIO: "true"
 
   # Enable caching across builds, set to "" to disable
   CACHE_FROM: type=gha
@@ -69,7 +68,7 @@ jobs:
 
       - name: Get build-number by looking at existing tags
         id: quayio
-        uses: manics/action-get-quayio-tags@v0.1.0
+        uses: jupyterhub/action-get-quayio-tags@v0.1.0
         with:
           repository: ${{ env.IMAGE }}
           version: ${{ steps.version.outputs.VERSION }}

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # JupyterHub Container Images
 
-[![Build](https://github.com/manics/jupyterhub-container-images/actions/workflows/build.yml/badge.svg)](https://github.com/manics/jupyterhub-container-images/actions/workflows/build.yml)
+[![Build](https://github.com/jupyterhub/jupyterhub-container-images/actions/workflows/build.yml/badge.svg)](https://github.com/jupyterhub/jupyterhub-container-images/actions/workflows/build.yml)
 
 Definitions and workflows for publishing JupyterHub container images.
 
@@ -20,13 +20,13 @@ where `MAJOR.MINOR.PATCH` is the JupyterHub version.
 ## Publishing backports
 
 Backports are published in their own branches.
-For example, see https://github.com/manics/jupyterhub-container-images/compare/main..4.x
+For example, see https://github.com/jupyterhub/jupyterhub-container-images/compare/main..4.x
 
 ## Images
 
 The following images are published by this repository:
 
-- jupyterhub
-- jupyterhub-onbuild
-- jupyterhub-demo
-- jupyterhub-singleuser
+- [jupyterhub/jupyterhub](https://quay.io/repository/jupyterhub/jupyterhub?tab=tags)
+- [jupyterhub/jupyterhub-onbuild](https://quay.io/repository/jupyterhub/jupyterhub-onbuild?tab=tags)
+- [jupyterhub/jupyterhub-demo](https://quay.io/repository/jupyterhub/jupyterhub-demo?tab=tags)
+- [jupyterhub/singleuser](https://quay.io/repository/jupyterhub/singleuser?tab=tags)


### PR DESCRIPTION
https://github.com/jupyterhub/jupyterhub/issues/4954
After this is merged the remaining steps are to add secrets:
- `QUAY_USERNAME`
- `QUAY_PASSWORD`
- `DOCKERHUB_USERNAME`
- `DOCKERHUB_TOKEN`

For now the build will fail after merging.