### PR TITLE
add watch-dependencies workflow to run pip-compile

### DIFF
--- a/.github/workflows/watch-dependencies.yaml
+++ b/.github/workflows/watch-dependencies.yaml
@@ -1,0 +1,81 @@
+# This is a GitHub workflow defining a set of jobs with a set of steps.
+# ref: https://docs.github.com/en/actions/learn-github-actions/workflow-syntax-for-github-actions
+#
+# - Update `requirements.txt` from `requirements.in` with pip-compile
+#
+# About environment: watch-dependencies
+#
+# To reduce the exposure of the secrets.jupyterhub_bot_pat token that was setup
+# for the environment watch-dependencies, we have setup a dedicated environment
+# according to steps in
+# https://github.com/jupyterhub/team-compass/issues/516#issuecomment-1129961954.
+
+name: Watch dependencies
+
+on:
+  push:
+    paths:
+      - "**/requirements.txt"
+      - ".github/workflows/watch-dependencies.yaml"
+    branches:
+      - main
+  schedule:
+    # Run at 05:00 every day, ref: https://crontab.guru/#0_5_*_*_*
+    - cron: "0 5 * * *"
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+jobs:
+  update-image-dependencies:
+    # Don't run this job on forks
+    if: github.repository == 'jupyterhub/jupyterhub-container-images'
+    runs-on: ubuntu-24.04
+    environment: watch-dependencies
+
+    strategy:
+      matrix:
+        image:
+          # list of image directories with pip-compile inputs
+          # (currently only one)
+          - base
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          persist-credentials: false
+      - uses: actions/setup-python@v5
+        with:
+          # this should match the Python version in base/Dockerfile
+          python-version: 3.10
+      - name: install pip-tools
+        run: |
+          pip install --upgrade pip
+          pip install pip-tools
+          pip list --format=freeze
+
+      - name: update requirements.txt with pip-compile
+        run: |
+          pip-compile --allow-unsafe --strip-extras --upgrade
+
+        env:
+          CUSTOM_COMPILE_COMMAND: >
+            Use the "Run workflow" button at https://github.com/jupyterhub/jupyterhub-container-images/actions/workflows/watch-dependencies.yaml
+        working-directory: ${{ matrix.image }}
+
+      - name: git diff
+        run: git --no-pager diff --color=always
+
+      # ref: https://github.com/peter-evans/create-pull-request
+      - name: Create a PR
+        uses: peter-evans/create-pull-request@v7
+        with:
+          token: "${{ secrets.jupyterhub_bot_pat }}"
+          author: JupyterHub Bot Account <105740858+jupyterhub-bot@users.noreply.github.com>
+          committer: JupyterHub Bot Account <105740858+jupyterhub-bot@users.noreply.github.com>
+          branch: update-requirements/${{ matrix.image }}
+          labels: dependencies
+          commit-message: "${{ matrix.image }}: refreeze requirements.txt"
+          title: "${{ matrix.image }}: refreeze requirements.txt"
+          body: >-
+            The ${{ matrix.image }} requirements.txt has been refrozen with pip-compile.


### PR DESCRIPTION
run in the workflow instead of docker since we're simple for now

closes #8 (it would be nice if dependabot worked instead, but it doesn't)