### PR TITLE
watch-dependencies.yaml: Python 3.10 needs to be quoted

### DIFF
--- a/.github/workflows/watch-dependencies.yaml
+++ b/.github/workflows/watch-dependencies.yaml
@@ -47,7 +47,7 @@ jobs:
       - uses: actions/setup-python@v5
         with:
           # this should match the Python version in base/Dockerfile
-          python-version: 3.10
+          python-version: '3.10'
       - name: install pip-tools
         run: |
           pip install --upgrade pip


### PR DESCRIPTION
Otherwise it's interpreted as `3.1`