### PR TITLE
can't use strict tags when building prereleases

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -77,7 +77,8 @@ jobs:
           # assume it's a backport branch which means we need to get all tags to work out
           # which MAJOR and MAJOR.MINOR aliases are needed.
           allTags: ${{ (github.ref != format('refs/heads/{0}', env.LATEST_BRANCH)) && (github.base_ref != format('refs/heads/{0}', env.LATEST_BRANCH)) }}
-          strict: "true"
+          # can't use strict when building prereleases
+          strict: "false"
 
       - name: Get new tag # zizmor: ignore[template-injection]
         id: new

--- a/.github/workflows/watch-dependencies.yaml
+++ b/.github/workflows/watch-dependencies.yaml
@@ -47,7 +47,7 @@ jobs:
       - uses: actions/setup-python@v5
         with:
           # this should match the Python version in base/Dockerfile
-          python-version: '3.10'
+          python-version: "3.10"
       - name: install pip-tools
         run: |
           pip install --upgrade pip


### PR DESCRIPTION
unclear why this succeeded in #7, it doesn't seem like it should have