### PR TITLE
Disable some zizmor rules, increase build timeout

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -88,7 +88,7 @@ jobs:
 
   publish-docker:
     runs-on: ubuntu-24.04
-    timeout-minutes: 30
+    timeout-minutes: 45
     needs:
       - tag
 

--- a/.github/workflows/watch-dependencies.yaml
+++ b/.github/workflows/watch-dependencies.yaml
@@ -68,7 +68,7 @@ jobs:
 
       # ref: https://github.com/peter-evans/create-pull-request
       - name: Create a PR
-        uses: peter-evans/create-pull-request@v7
+        uses: peter-evans/create-pull-request@271a8d0340265f705b14b6d32b9829c1cb33d45e # v7.0.8
         with:
           token: "${{ secrets.jupyterhub_bot_pat }}"
           author: JupyterHub Bot Account <105740858+jupyterhub-bot@users.noreply.github.com>

--- a/.github/zizmor.yml
+++ b/.github/zizmor.yml
@@ -1,0 +1,11 @@
+# Zizmor configuration file
+rules:
+  unpinned-uses:
+    config:
+      policies:
+        # Zizmor defaults to requiring pinning by immutable hashes.
+        # Allow pinning by refs for trusted organisations.
+        # https://woodruffw.github.io/zizmor/audits/#rulesunpinned-usesconfigpolicies
+        actions/*: ref-pin
+        docker/*: ref-pin
+        jupyterhub/*: ref-pin

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -22,7 +22,7 @@ repos:
 
   # autoformat and lint Python code
   - repo: https://github.com/astral-sh/ruff-pre-commit
-    rev: v0.11.4
+    rev: v0.11.8
     hooks:
       - id: ruff
         args: ["--select=I", "--fix", "--show-fixes"]
@@ -30,6 +30,6 @@ repos:
 
   # Static security analysis of GitHub actions https://github.com/woodruffw/zizmor
   - repo: https://github.com/woodruffw/zizmor-pre-commit
-    rev: v1.5.2
+    rev: v1.6.0
     hooks:
       - id: zizmor

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -29,6 +29,7 @@ repos:
       - id: ruff-format
 
   # Static security analysis of GitHub actions https://github.com/woodruffw/zizmor
+  # Additional config is in .github/zizmor.yml
   - repo: https://github.com/woodruffw/zizmor-pre-commit
     rev: v1.6.0
     hooks:


### PR DESCRIPTION
Closes https://github.com/jupyterhub/jupyterhub-container-images/pull/21 which bumps the zizmor version and brings in stricter rules.

I've also increased the build timeout to 45 minutes because https://github.com/jupyterhub/jupyterhub-container-images/actions/runs/14869298623 failed after building the first image, perhaps because the docker gha cache had expired leading to longer build times?