### PR TITLE
Pin configurable-http-proxy dependencies

### DIFF
--- a/base/Dockerfile
+++ b/base/Dockerfile
@@ -75,9 +75,17 @@ RUN apt-get update -qq \
     nodejs \
     npm \
  && locale-gen $LC_ALL \
- && npm install -g configurable-http-proxy@^4.6.2 \
  # clean cache and logs
- && rm -rf /var/lib/apt/lists/* /var/log/* /var/tmp/* ~/.npm
+ && rm -rf /var/lib/apt/lists/* /var/log/* /var/tmp/*
+
+# Install configurable-http-proxy, but pin all dependencies
+# Note npm install -g doesn't work with package.json so do it manually
+COPY package-lock.json package.json /usr/local/lib/
+RUN cd /usr/local/lib \
+ && npm install \
+ && ln -s ../lib/node_modules/configurable-http-proxy/bin/configurable-http-proxy /usr/local/bin/ \
+ && rm -rf ~/.npm
+
 # install the wheels we built in the previous stage
 RUN --mount=type=cache,from=wheel-builder,source=/src/jupyterhub/wheelhouse,target=/tmp/wheelhouse \
     # always make sure pip is up to date!

--- a/base/package-lock.json
+++ b/base/package-lock.json
@@ -1,0 +1,603 @@
+{
+  "name": "jupyterhub-dependencies",
+  "lockfileVersion": 2,
+  "requires": true,
+  "packages": {
+    "node_modules/configurable-http-proxy": {
+      "version": "4.6.3",
+      "extraneous": true,
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "commander": "~7.2",
+        "http-proxy-node16": "1.0.5",
+        "prom-client": "14.2.0",
+        "strftime": "~0.10.0",
+        "winston": "~3.15.0"
+      },
+      "bin": {
+        "configurable-http-proxy": "bin/configurable-http-proxy"
+      },
+      "engines": {
+        "node": ">= 10.0"
+      }
+    },
+    "node_modules/configurable-http-proxy/node_modules/@colors/colors": {
+      "version": "1.6.0",
+      "extraneous": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.1.90"
+      }
+    },
+    "node_modules/configurable-http-proxy/node_modules/@dabh/diagnostics": {
+      "version": "2.0.3",
+      "extraneous": true,
+      "license": "MIT",
+      "dependencies": {
+        "colorspace": "1.1.x",
+        "enabled": "2.0.x",
+        "kuler": "^2.0.0"
+      }
+    },
+    "node_modules/configurable-http-proxy/node_modules/@types/triple-beam": {
+      "version": "1.3.5",
+      "extraneous": true,
+      "license": "MIT"
+    },
+    "node_modules/configurable-http-proxy/node_modules/async": {
+      "version": "3.2.6",
+      "extraneous": true,
+      "license": "MIT"
+    },
+    "node_modules/configurable-http-proxy/node_modules/bintrees": {
+      "version": "1.0.2",
+      "extraneous": true,
+      "license": "MIT"
+    },
+    "node_modules/configurable-http-proxy/node_modules/color": {
+      "version": "3.2.1",
+      "extraneous": true,
+      "license": "MIT",
+      "dependencies": {
+        "color-convert": "^1.9.3",
+        "color-string": "^1.6.0"
+      }
+    },
+    "node_modules/configurable-http-proxy/node_modules/color-convert": {
+      "version": "1.9.3",
+      "extraneous": true,
+      "license": "MIT",
+      "dependencies": {
+        "color-name": "1.1.3"
+      }
+    },
+    "node_modules/configurable-http-proxy/node_modules/color-name": {
+      "version": "1.1.3",
+      "extraneous": true,
+      "license": "MIT"
+    },
+    "node_modules/configurable-http-proxy/node_modules/color-string": {
+      "version": "1.9.1",
+      "extraneous": true,
+      "license": "MIT",
+      "dependencies": {
+        "color-name": "^1.0.0",
+        "simple-swizzle": "^0.2.2"
+      }
+    },
+    "node_modules/configurable-http-proxy/node_modules/colorspace": {
+      "version": "1.1.4",
+      "extraneous": true,
+      "license": "MIT",
+      "dependencies": {
+        "color": "^3.1.3",
+        "text-hex": "1.0.x"
+      }
+    },
+    "node_modules/configurable-http-proxy/node_modules/commander": {
+      "version": "7.2.0",
+      "extraneous": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/configurable-http-proxy/node_modules/enabled": {
+      "version": "2.0.0",
+      "extraneous": true,
+      "license": "MIT"
+    },
+    "node_modules/configurable-http-proxy/node_modules/eventemitter3": {
+      "version": "4.0.7",
+      "extraneous": true,
+      "license": "MIT"
+    },
+    "node_modules/configurable-http-proxy/node_modules/fecha": {
+      "version": "4.2.3",
+      "extraneous": true,
+      "license": "MIT"
+    },
+    "node_modules/configurable-http-proxy/node_modules/fn.name": {
+      "version": "1.1.0",
+      "extraneous": true,
+      "license": "MIT"
+    },
+    "node_modules/configurable-http-proxy/node_modules/follow-redirects": {
+      "version": "1.15.11",
+      "extraneous": true,
+      "funding": [
+        {
+          "type": "individual",
+          "url": "https://github.com/sponsors/RubenVerborgh"
+        }
+      ],
+      "license": "MIT",
+      "engines": {
+        "node": ">=4.0"
+      },
+      "peerDependenciesMeta": {
+        "debug": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/configurable-http-proxy/node_modules/http-proxy-node16": {
+      "version": "1.0.5",
+      "extraneous": true,
+      "license": "MIT",
+      "dependencies": {
+        "eventemitter3": "^4.0.0",
+        "follow-redirects": "^1.0.0",
+        "requires-port": "^1.0.0"
+      },
+      "engines": {
+        "node": ">=8.0.0"
+      }
+    },
+    "node_modules/configurable-http-proxy/node_modules/inherits": {
+      "version": "2.0.4",
+      "extraneous": true,
+      "license": "ISC"
+    },
+    "node_modules/configurable-http-proxy/node_modules/is-arrayish": {
+      "version": "0.3.2",
+      "extraneous": true,
+      "license": "MIT"
+    },
+    "node_modules/configurable-http-proxy/node_modules/is-stream": {
+      "version": "2.0.1",
+      "extraneous": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/configurable-http-proxy/node_modules/kuler": {
+      "version": "2.0.0",
+      "extraneous": true,
+      "license": "MIT"
+    },
+    "node_modules/configurable-http-proxy/node_modules/logform": {
+      "version": "2.7.0",
+      "extraneous": true,
+      "license": "MIT",
+      "dependencies": {
+        "@colors/colors": "1.6.0",
+        "@types/triple-beam": "^1.3.2",
+        "fecha": "^4.2.0",
+        "ms": "^2.1.1",
+        "safe-stable-stringify": "^2.3.1",
+        "triple-beam": "^1.3.0"
+      },
+      "engines": {
+        "node": ">= 12.0.0"
+      }
+    },
+    "node_modules/configurable-http-proxy/node_modules/ms": {
+      "version": "2.1.3",
+      "extraneous": true,
+      "license": "MIT"
+    },
+    "node_modules/configurable-http-proxy/node_modules/one-time": {
+      "version": "1.0.0",
+      "extraneous": true,
+      "license": "MIT",
+      "dependencies": {
+        "fn.name": "1.x.x"
+      }
+    },
+    "node_modules/configurable-http-proxy/node_modules/prom-client": {
+      "version": "14.2.0",
+      "extraneous": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "tdigest": "^0.1.1"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/configurable-http-proxy/node_modules/readable-stream": {
+      "version": "3.6.2",
+      "extraneous": true,
+      "license": "MIT",
+      "dependencies": {
+        "inherits": "^2.0.3",
+        "string_decoder": "^1.1.1",
+        "util-deprecate": "^1.0.1"
+      },
+      "engines": {
+        "node": ">= 6"
+      }
+    },
+    "node_modules/configurable-http-proxy/node_modules/requires-port": {
+      "version": "1.0.0",
+      "extraneous": true,
+      "license": "MIT"
+    },
+    "node_modules/configurable-http-proxy/node_modules/safe-buffer": {
+      "version": "5.2.1",
+      "extraneous": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ],
+      "license": "MIT"
+    },
+    "node_modules/configurable-http-proxy/node_modules/safe-stable-stringify": {
+      "version": "2.5.0",
+      "extraneous": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/configurable-http-proxy/node_modules/simple-swizzle": {
+      "version": "0.2.2",
+      "extraneous": true,
+      "license": "MIT",
+      "dependencies": {
+        "is-arrayish": "^0.3.1"
+      }
+    },
+    "node_modules/configurable-http-proxy/node_modules/stack-trace": {
+      "version": "0.0.10",
+      "extraneous": true,
+      "license": "MIT",
+      "engines": {
+        "node": "*"
+      }
+    },
+    "node_modules/configurable-http-proxy/node_modules/strftime": {
+      "version": "0.10.3",
+      "extraneous": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.2.0"
+      }
+    },
+    "node_modules/configurable-http-proxy/node_modules/string_decoder": {
+      "version": "1.3.0",
+      "extraneous": true,
+      "license": "MIT",
+      "dependencies": {
+        "safe-buffer": "~5.2.0"
+      }
+    },
+    "node_modules/configurable-http-proxy/node_modules/tdigest": {
+      "version": "0.1.2",
+      "extraneous": true,
+      "license": "MIT",
+      "dependencies": {
+        "bintrees": "1.0.2"
+      }
+    },
+    "node_modules/configurable-http-proxy/node_modules/text-hex": {
+      "version": "1.0.0",
+      "extraneous": true,
+      "license": "MIT"
+    },
+    "node_modules/configurable-http-proxy/node_modules/triple-beam": {
+      "version": "1.4.1",
+      "extraneous": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 14.0.0"
+      }
+    },
+    "node_modules/configurable-http-proxy/node_modules/util-deprecate": {
+      "version": "1.0.2",
+      "extraneous": true,
+      "license": "MIT"
+    },
+    "node_modules/configurable-http-proxy/node_modules/winston": {
+      "version": "3.15.0",
+      "extraneous": true,
+      "license": "MIT",
+      "dependencies": {
+        "@colors/colors": "^1.6.0",
+        "@dabh/diagnostics": "^2.0.2",
+        "async": "^3.2.3",
+        "is-stream": "^2.0.0",
+        "logform": "^2.6.0",
+        "one-time": "^1.0.0",
+        "readable-stream": "^3.4.0",
+        "safe-stable-stringify": "^2.3.1",
+        "stack-trace": "0.0.x",
+        "triple-beam": "^1.3.0",
+        "winston-transport": "^4.7.0"
+      },
+      "engines": {
+        "node": ">= 12.0.0"
+      }
+    },
+    "node_modules/configurable-http-proxy/node_modules/winston-transport": {
+      "version": "4.9.0",
+      "extraneous": true,
+      "license": "MIT",
+      "dependencies": {
+        "logform": "^2.7.0",
+        "readable-stream": "^3.6.2",
+        "triple-beam": "^1.3.0"
+      },
+      "engines": {
+        "node": ">= 12.0.0"
+      }
+    }
+  },
+  "dependencies": {
+    "configurable-http-proxy": {
+      "version": "4.6.3",
+      "extraneous": true,
+      "requires": {
+        "commander": "~7.2",
+        "http-proxy-node16": "1.0.5",
+        "prom-client": "14.2.0",
+        "strftime": "~0.10.0",
+        "winston": "~3.15.0"
+      },
+      "dependencies": {
+        "@colors/colors": {
+          "version": "1.6.0",
+          "extraneous": true
+        },
+        "@dabh/diagnostics": {
+          "version": "2.0.3",
+          "extraneous": true,
+          "requires": {
+            "colorspace": "1.1.x",
+            "enabled": "2.0.x",
+            "kuler": "^2.0.0"
+          }
+        },
+        "@types/triple-beam": {
+          "version": "1.3.5",
+          "extraneous": true
+        },
+        "async": {
+          "version": "3.2.6",
+          "extraneous": true
+        },
+        "bintrees": {
+          "version": "1.0.2",
+          "extraneous": true
+        },
+        "color": {
+          "version": "3.2.1",
+          "extraneous": true,
+          "requires": {
+            "color-convert": "^1.9.3",
+            "color-string": "^1.6.0"
+          }
+        },
+        "color-convert": {
+          "version": "1.9.3",
+          "extraneous": true,
+          "requires": {
+            "color-name": "1.1.3"
+          }
+        },
+        "color-name": {
+          "version": "1.1.3",
+          "extraneous": true
+        },
+        "color-string": {
+          "version": "1.9.1",
+          "extraneous": true,
+          "requires": {
+            "color-name": "^1.0.0",
+            "simple-swizzle": "^0.2.2"
+          }
+        },
+        "colorspace": {
+          "version": "1.1.4",
+          "extraneous": true,
+          "requires": {
+            "color": "^3.1.3",
+            "text-hex": "1.0.x"
+          }
+        },
+        "commander": {
+          "version": "7.2.0",
+          "extraneous": true
+        },
+        "enabled": {
+          "version": "2.0.0",
+          "extraneous": true
+        },
+        "eventemitter3": {
+          "version": "4.0.7",
+          "extraneous": true
+        },
+        "fecha": {
+          "version": "4.2.3",
+          "extraneous": true
+        },
+        "fn.name": {
+          "version": "1.1.0",
+          "extraneous": true
+        },
+        "follow-redirects": {
+          "version": "1.15.11",
+          "extraneous": true
+        },
+        "http-proxy-node16": {
+          "version": "1.0.5",
+          "extraneous": true,
+          "requires": {
+            "eventemitter3": "^4.0.0",
+            "follow-redirects": "^1.0.0",
+            "requires-port": "^1.0.0"
+          }
+        },
+        "inherits": {
+          "version": "2.0.4",
+          "extraneous": true
+        },
+        "is-arrayish": {
+          "version": "0.3.2",
+          "extraneous": true
+        },
+        "is-stream": {
+          "version": "2.0.1",
+          "extraneous": true
+        },
+        "kuler": {
+          "version": "2.0.0",
+          "extraneous": true
+        },
+        "logform": {
+          "version": "2.7.0",
+          "extraneous": true,
+          "requires": {
+            "@colors/colors": "1.6.0",
+            "@types/triple-beam": "^1.3.2",
+            "fecha": "^4.2.0",
+            "ms": "^2.1.1",
+            "safe-stable-stringify": "^2.3.1",
+            "triple-beam": "^1.3.0"
+          }
+        },
+        "ms": {
+          "version": "2.1.3",
+          "extraneous": true
+        },
+        "one-time": {
+          "version": "1.0.0",
+          "extraneous": true,
+          "requires": {
+            "fn.name": "1.x.x"
+          }
+        },
+        "prom-client": {
+          "version": "14.2.0",
+          "extraneous": true,
+          "requires": {
+            "tdigest": "^0.1.1"
+          }
+        },
+        "readable-stream": {
+          "version": "3.6.2",
+          "extraneous": true,
+          "requires": {
+            "inherits": "^2.0.3",
+            "string_decoder": "^1.1.1",
+            "util-deprecate": "^1.0.1"
+          }
+        },
+        "requires-port": {
+          "version": "1.0.0",
+          "extraneous": true
+        },
+        "safe-buffer": {
+          "version": "5.2.1",
+          "extraneous": true
+        },
+        "safe-stable-stringify": {
+          "version": "2.5.0",
+          "extraneous": true
+        },
+        "simple-swizzle": {
+          "version": "0.2.2",
+          "extraneous": true,
+          "requires": {
+            "is-arrayish": "^0.3.1"
+          }
+        },
+        "stack-trace": {
+          "version": "0.0.10",
+          "extraneous": true
+        },
+        "strftime": {
+          "version": "0.10.3",
+          "extraneous": true
+        },
+        "string_decoder": {
+          "version": "1.3.0",
+          "extraneous": true,
+          "requires": {
+            "safe-buffer": "~5.2.0"
+          }
+        },
+        "tdigest": {
+          "version": "0.1.2",
+          "extraneous": true,
+          "requires": {
+            "bintrees": "1.0.2"
+          }
+        },
+        "text-hex": {
+          "version": "1.0.0",
+          "extraneous": true
+        },
+        "triple-beam": {
+          "version": "1.4.1",
+          "extraneous": true
+        },
+        "util-deprecate": {
+          "version": "1.0.2",
+          "extraneous": true
+        },
+        "winston": {
+          "version": "3.15.0",
+          "extraneous": true,
+          "requires": {
+            "@colors/colors": "^1.6.0",
+            "@dabh/diagnostics": "^2.0.2",
+            "async": "^3.2.3",
+            "is-stream": "^2.0.0",
+            "logform": "^2.6.0",
+            "one-time": "^1.0.0",
+            "readable-stream": "^3.4.0",
+            "safe-stable-stringify": "^2.3.1",
+            "stack-trace": "0.0.x",
+            "triple-beam": "^1.3.0",
+            "winston-transport": "^4.7.0"
+          }
+        },
+        "winston-transport": {
+          "version": "4.9.0",
+          "extraneous": true,
+          "requires": {
+            "logform": "^2.7.0",
+            "readable-stream": "^3.6.2",
+            "triple-beam": "^1.3.0"
+          }
+        }
+      }
+    }
+  }
+}

--- a/base/package.json
+++ b/base/package.json
@@ -1,0 +1,6 @@
+{
+  "name": "jupyterhub-dependencies",
+  "dependencies": {
+    "configurable-http-proxy": "^4.6.3"
+  }
+}


### PR DESCRIPTION
`package-lock.json` was created by running `npm shrinkwrap` in the `/usr/local/lib` directory of `quay.io/jupyterhub/jupyterhub:5.3.0-17` and changing the `name` field from `lib` to `jupyterhub-dependencies`

Closes https://github.com/jupyterhub/jupyterhub-container-images/issues/40
