### PR TITLE
update certipy 0.2.3

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -31,7 +31,7 @@ repos:
   # Static security analysis of GitHub actions https://github.com/woodruffw/zizmor
   # Additional config is in .github/zizmor.yml
   - repo: https://github.com/woodruffw/zizmor-pre-commit
-    rev: v1.23.1
+    rev: v1.24.1
     hooks:
       - id: zizmor
         args:

--- a/base/requirements.txt
+++ b/base/requirements.txt
@@ -3,7 +3,6 @@
 # by the following command:
 #
 #    Use the "Run workflow" button at https://github.com/jupyterhub/jupyterhub-container-images/actions/workflows/watch-dependencies.yaml
-
 #
 alembic==1.18.4
     # via jupyterhub
@@ -17,7 +16,7 @@ attrs==26.1.0
     #   referencing
 certifi==2026.4.22
     # via requests
-certipy==0.2.2
+certipy==0.2.3
     # via jupyterhub
 cffi==2.0.0
     # via cryptography


### PR DESCRIPTION
fixes compatibility with cryptography 47, needed for internal ssl