### PR TITLE
Group github-action updates

### DIFF
--- a/.github/dependabot.yaml
+++ b/.github/dependabot.yaml
@@ -13,7 +13,7 @@ updates:
     groups:
       github-actions:
         patterns:
-          - '*'
+          - "*"
   # base/requirements.txt: security fixes only
   # Other version updates are handled by workflows/watch-dependencies.yaml
   - package-ecosystem: pip

--- a/.github/dependabot.yaml
+++ b/.github/dependabot.yaml
@@ -10,6 +10,10 @@ updates:
       interval: monthly
     cooldown:
       default-days: 7
+    groups:
+      github-actions:
+        patterns:
+          - '*'
   # base/requirements.txt: security fixes only
   # Other version updates are handled by workflows/watch-dependencies.yaml
   - package-ecosystem: pip

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -153,7 +153,7 @@ jobs:
       # this is a backported tag in which case the newer tags aren't updated.
       - name: Calculate tags
         id: jupyterhubtags
-        uses: jupyterhub/action-major-minor-tag-calculator@v3
+        uses: jupyterhub/action-major-minor-tag-calculator@v4
         with:
           existingTags: ${{ needs.tag.outputs.existing-tags }}
           newTag: ${{ needs.tag.outputs.new-tag }}
@@ -184,7 +184,7 @@ jobs:
       #
       - name: Get list of jupyterhub-demo tags
         id: demotags
-        uses: jupyterhub/action-major-minor-tag-calculator@v3
+        uses: jupyterhub/action-major-minor-tag-calculator@v4
         with:
           existingTags: ${{ needs.tag.outputs.existing-tags }}
           newTag: ${{ needs.tag.outputs.new-tag }}
@@ -209,7 +209,7 @@ jobs:
       #
       - name: Get list of jupyterhub/singleuser tags
         id: singleusertags
-        uses: jupyterhub/action-major-minor-tag-calculator@v3
+        uses: jupyterhub/action-major-minor-tag-calculator@v4
         with:
           existingTags: ${{ needs.tag.outputs.existing-tags }}
           newTag: ${{ needs.tag.outputs.new-tag }}

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -69,7 +69,7 @@ jobs:
 
       - name: Get build-number by looking at existing tags
         id: quayio
-        uses: jupyterhub/action-get-quayio-tags@v0.1.0
+        uses: jupyterhub/action-get-quayio-tags@v1.0.0
         with:
           repository: ${{ env.IMAGE }}
           version: ${{ steps.version.outputs.VERSION }}

--- a/.github/workflows/watch-dependencies.yaml
+++ b/.github/workflows/watch-dependencies.yaml
@@ -68,7 +68,7 @@ jobs:
 
       # ref: https://github.com/peter-evans/create-pull-request
       - name: Create a PR
-        uses: peter-evans/create-pull-request@c0f553fe549906ede9cf27b5156039d195d2ece0 # v8.1.0
+        uses: peter-evans/create-pull-request@5f6978faf089d4d20b00c7766989d076bb2fc7f1 # v8.1.1
         with:
           token: "${{ secrets.jupyterhub_bot_pat }}"
           author: JupyterHub Bot Account <105740858+jupyterhub-bot@users.noreply.github.com>


### PR DESCRIPTION
We publish an image after every merge, so try to minimise the number of PRs.

Closes https://github.com/jupyterhub/jupyterhub-container-images/pull/89
Closes https://github.com/jupyterhub/jupyterhub-container-images/pull/90
Closes https://github.com/jupyterhub/jupyterhub-container-images/pull/91